### PR TITLE
Bugfixes for the update from opentelemetry `0.27` to `0.28`

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -538,9 +538,9 @@ dependencies = [
 
 [[package]]
 name = "aws-sdk-dynamodb"
-version = "1.85.0"
+version = "1.86.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "14858fbb29becf03da3b021209feb6bc0caf2e40eb7022b633785f3bcf80d702"
+checksum = "0c8564fccc46e75aa2b7efda5b74ca2b8d5ec14d63ec4b6c14d55fac39380d44"
 dependencies = [
  "aws-credential-types",
  "aws-runtime",
@@ -560,9 +560,9 @@ dependencies = [
 
 [[package]]
 name = "aws-sdk-sso"
-version = "1.77.0"
+version = "1.78.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "18f2f37fea82468fe3f5a059542c05392ef680c4f7f00e0db02df8b6e5c7d0c6"
+checksum = "dbd7bc4bd34303733bded362c4c997a39130eac4310257c79aae8484b1c4b724"
 dependencies = [
  "aws-credential-types",
  "aws-runtime",
@@ -582,9 +582,9 @@ dependencies = [
 
 [[package]]
 name = "aws-sdk-ssooidc"
-version = "1.78.0"
+version = "1.79.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "ecb4f6eada20e0193450cd48b12ed05e1e66baac86f39160191651b932f2b7d9"
+checksum = "77358d25f781bb106c1a69531231d4fd12c6be904edb0c47198c604df5a2dbca"
 dependencies = [
  "aws-credential-types",
  "aws-runtime",
@@ -604,9 +604,9 @@ dependencies = [
 
 [[package]]
 name = "aws-sdk-sts"
-version = "1.79.0"
+version = "1.80.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "317377afba3498fca4948c5d32b399ef9a5ad35561a1e8a6f2ac7273dabf802d"
+checksum = "06e3ed2a9b828ae7763ddaed41d51724d2661a50c45f845b08967e52f4939cfc"
 dependencies = [
  "aws-credential-types",
  "aws-runtime",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -142,7 +142,7 @@ indexmap = "2"
 itertools = "0.14"
 lazy_static = "1.5"
 opentelemetry = "0.28"
-opentelemetry-otlp = "0.28"
+opentelemetry-otlp = { version = "0.28", default-features = false, features = ["grpc-tonic", "http", "http-proto", "reqwest-blocking-client", "metrics", "trace", "logs"] }
 opentelemetry_sdk = "0.28"
 path-absolutize = "3"
 quote = "1"

--- a/crates/factor-otel/Cargo.toml
+++ b/crates/factor-otel/Cargo.toml
@@ -9,7 +9,7 @@ anyhow = { workspace = true }
 indexmap = "2.2.6"
 opentelemetry = { workspace = true }
 opentelemetry_sdk = { workspace = true }
-opentelemetry-otlp = { workspace = true, features = ["http-proto", "http", "reqwest-client"] }
+opentelemetry-otlp = { workspace = true }
 spin-core = { path = "../core" }
 spin-factors = { path = "../factors" }
 spin-resource-table = { path = "../table" }

--- a/crates/telemetry/Cargo.toml
+++ b/crates/telemetry/Cargo.toml
@@ -10,7 +10,7 @@ http0 = { version = "0.2.9", package = "http" }
 http1 = { version = "1.0.0", package = "http" }
 opentelemetry = { version = "0.28", features = ["metrics", "trace", "logs"] }
 opentelemetry-appender-tracing = "0.28"
-opentelemetry-otlp = { workspace = true, features = ["grpc-tonic"] }
+opentelemetry-otlp = { workspace = true }
 opentelemetry_sdk = { workspace = true, features = ["rt-tokio", "spec_unstable_logs_enabled", "metrics"] }
 terminal = { path = "../terminal" }
 tracing = { workspace = true }


### PR DESCRIPTION
Good news is I was able to figure out why we were getting a `Exporter no http client` error:
-  I found [this issue](https://github.com/open-telemetry/opentelemetry-rust/issues/2994), and it made me wonder if we were having problems because of possible conflicting HTTP clients in the code. 
- I ended up moving the `opentelemetry-otlp = { features }` to `/Cargo.toml`, and the error disappeared

The bad news is we have 2 broken scenarios:
- If I use the default `reqwest-blocking-client` (non-async), the `spin-basic` app only exports 4/6 of the expected spans
- We can't use the `reqwest-client` (async). Per the [documentation](https://docs.rs/opentelemetry_sdk/0.28.0/opentelemetry_sdk/trace/struct.BatchSpanProcessor.html), it is is no longer supported for the use with the `BatchSpanProcessor`. Here's the runtime error I get as proof:
```sh
$ spin up
Serving http://127.0.0.1:3000
Available Routes:
  spin-basic: http://127.0.0.1:3000 (wildcard)
2025-07-26T00:22:08.515335Z TRACE spin_trigger_http::server: monotonic_counter.spin.request_count=1 trigger_type="http" app_id="spin-basic" component_id="spin-basic"

thread 'OpenTelemetry.Traces.BatchProcessor' panicked at /home/asteurer/.rustup/toolchains/stable-x86_64-unknown-linux-gnu/lib/rustlib/src/rust/library/core/src/ops/function.rs:250:5:
there is no reactor running, must be called from the context of a Tokio 1.x runtime
note: run with `RUST_BACKTRACE=1` environment variable to display a backtrace
```

I'm not sure how to proceed. Any thoughts?